### PR TITLE
Adding a GHA to build a docker image

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,27 @@
+name: "builds a addon_urbanisme docker image"
+on:
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "checking out"
+        uses: actions/checkout@v2
+
+      - name: "builds the docker image"
+        run: |
+          mvn clean package
+          cd target/docker/urbanisme && docker build -t sigrennesmetropole/addon_urbanisme:latest .
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to docker-hub
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: "pushes the docker image"
+        run: |
+          docker push sigrennesmetropole/addon_urbanisme:latest

--- a/pom.xml
+++ b/pom.xml
@@ -207,14 +207,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
-    </repository>
-    <repository>
       <id>opengeo</id>
       <name>OSGeo Release Repository</name>
       <url>https://repo.osgeo.org/repository/release/</url>
@@ -226,14 +218,6 @@
       <id>jetty-repository</id>
       <name>Jetty Maven2 Repository</name>
       <url>https://oss.sonatype.org/content/groups/jetty/</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>bintray</id>
-      <name>bintray</name>
-      <url>http://dl.bintray.com/readytalk/maven</url>
     </repository>
     <repository>
       <id>sonatype</id>
@@ -250,6 +234,11 @@
   <build>
     <finalName>urbanisme</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+      </plugin>
       <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,14 @@
   </dependencies>
   <repositories>
     <repository>
+      <id>georchestra</id>
+      <name>geOrchestra's artifactory</name>
+      <url>https://artifactory.georchestra.org/artifactory/maven</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>opengeo</id>
       <name>OSGeo Release Repository</name>
       <url>https://repo.osgeo.org/repository/release/</url>


### PR DESCRIPTION
This PR also modifies the pom.xml to:

* update the maven-war-plugin
* remove outdated maven repositories (osgeo does not exist anymore, spring-plugins now returns 401 errors)
* Adds the geOrchestra artifactory repository (needed to resolve metrics3-statsd)

Note about metrics3-statsd: I could not figure out why it was needed, it seems to be required at runtime for the embedded mapfishprint, but then I could not explain why the dependency is not made publicly available onto more official maven repositories, @fnisseron any idea ?
